### PR TITLE
Remove klasaplugins.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -649,7 +649,6 @@ var cnames_active = {
   "kiwidocs": "arguiot.github.io/KiwiDocs",
   "klasa": "dirigeants.github.io/klasa-website",
   "klasy-eris": "motiontheking.github.io/klasy-eris",
-  "klasaplugins": "quantumlytangled.github.io/klasa-plugins-website",
   "klepto": "mwjaworski.github.io/klepto",
   "knowyourbundle": "enapupe.github.io/know-your-bundle",
   "ko": "ko25july.github.io/ko.js.org",


### PR DESCRIPTION
I would like to remove the domain klasaplugins.js.org . I am sorry for the work of adding it and removing it
